### PR TITLE
Add: do not restart service in case of error or upon exit

### DIFF
--- a/custom/kodi/areascout/gbm/overlay/etc/systemd/system/kodi.service
+++ b/custom/kodi/areascout/gbm/overlay/etc/systemd/system/kodi.service
@@ -4,7 +4,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-Restart=always
+Restart=no
 RestartSec=1
 @@ENVIRONMENT_HOME@@
 ExecStart=/usr/bin/kodi

--- a/custom/kodi/areascout/gbm/packages
+++ b/custom/kodi/areascout/gbm/packages
@@ -2,3 +2,4 @@ kodi
 libmali-rk-bifrost-g52-g2p0-gbm
 policykit-1
 xmlstarlet
+bluez


### PR DESCRIPTION
User can start it manually if needed, this is needed for some Add-ons which require to exit KODI.
