### PR TITLE
Start KODI with both Pulseaudio and ALSA audio backend, it's needed to connect to Bluetooth speakers

### DIFF
--- a/custom/kodi/areascout/gbm/fixups/S65-setup-kodi
+++ b/custom/kodi/areascout/gbm/fixups/S65-setup-kodi
@@ -24,6 +24,10 @@ xmlstarlet edit --inplace \
 
 # Kodi Service
 sed -i "s|@@ENVIRONMENT_HOME@@|Environment=\"HOME=/home/@@DEFAULT_USER@@\"|g" /etc/systemd/system/kodi.service
+sed -i "s|@@DEFAULT_SERVICE_USER@@|Environment=\"User=@@DEFAULT_USER@@\"|g" /etc/systemd/system/kodi.service
+
+# Set default Pulseaudio output sink for Kodi
+sed -i 's|#set-default-sink output|set-default-sink 0|g' /etc/pulse/default.pa
 
 chmod 644 /etc/systemd/system/kodi.service
 systemctl enable kodi

--- a/custom/kodi/areascout/gbm/overlay/etc/sudoers.d/1_kodi_permissions
+++ b/custom/kodi/areascout/gbm/overlay/etc/sudoers.d/1_kodi_permissions
@@ -1,0 +1,1 @@
+ALL ALL = NOPASSWD: /usr/bin/systemctl

--- a/custom/kodi/areascout/gbm/overlay/etc/systemd/system/kodi.service
+++ b/custom/kodi/areascout/gbm/overlay/etc/systemd/system/kodi.service
@@ -6,7 +6,7 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=no
 RestartSec=1
-User=odroid
+@@DEFAULT_SERVICE_USER@@
 @@ENVIRONMENT_HOME@@
 ExecStart=/bin/bash -c 'cd $HOME;export XDG_RUNTIME_DIR="/run/user/$UID";export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$UID/bus";sudo systemctl restart user@$UID.service;sleep 4;/usr/bin/pulseaudio --start -D;/usr/bin/kodi --audio-backend=alsa'
 

--- a/custom/kodi/areascout/gbm/overlay/etc/systemd/system/kodi.service
+++ b/custom/kodi/areascout/gbm/overlay/etc/systemd/system/kodi.service
@@ -6,8 +6,9 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=no
 RestartSec=1
+User=odroid
 @@ENVIRONMENT_HOME@@
-ExecStart=/usr/bin/kodi
+ExecStart=/bin/bash -c 'cd $HOME;export XDG_RUNTIME_DIR="/run/user/$UID";export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$UID/bus";sudo systemctl restart user@$UID.service;sleep 4;/usr/bin/pulseaudio --start -D;/usr/bin/kodi --audio-backend=alsa'
 
 [Install]
 WantedBy=multi-user.target

--- a/custom/kodi/areascout/gbm/packages
+++ b/custom/kodi/areascout/gbm/packages
@@ -3,3 +3,5 @@ libmali-rk-bifrost-g52-g2p0-gbm
 policykit-1
 xmlstarlet
 bluez
+pulseaudio
+pulseaudio-module-bluetooth


### PR DESCRIPTION
We also need to start KODI with **odroid** user, ~~maybe I have to declare @@DEFAULT_USER@@ inside the service ??~~

And maybe there is another way how I startup the user manager followed by Pulseaudio and at the end KODI, but I found it's the only working way that KODI recognize both audio backends and Pulseaudio was always tricky to start from within services as it needs Dbus and a Pulseaudio socket listen for connections prior to run Pulseaudio itself.

And starting KODI with _kodi --audio-backend=alsa+pulseaudio_ is not working, only Pulseaudio is showed but starting KODI with 
ALSA backend only, shows both Pulseaudio and ALSA (_kodi --audio-backend=alsa_)

 
![screenshot00001](https://github.com/tobetter/odroid-stamper/assets/1681560/9a69fcd8-2e77-4acf-83fe-53b03ae2c415)

Anyway, with this commit's it is tested and working
