### PR TITLE
Add: Do not exit Pulseaudio client if not used

### DIFF
--- a/custom/kodi/areascout/gbm/fixups/S65-setup-kodi
+++ b/custom/kodi/areascout/gbm/fixups/S65-setup-kodi
@@ -64,3 +64,6 @@ echo 'export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$UID/bus"' >> /home/@
 
 # Set default Pulseaudio output sink for Kodi
 sed -i 's|#set-default-sink output|set-default-sink 0|g' /etc/pulse/default.pa
+
+# Do not exit Pulseaudio client if unused
+sed -i 's/; exit-idle-time = 20/exit-idle-time = -1/g' /etc/pulse/daemon.conf


### PR DESCRIPTION
When not choosing PulseAudio as audio backend but ALSA and rebooting, it could be that the PulseAudio daemon quit itself before KODI was started, just disabling the daemon from quitting itself seems like to resolve this issue